### PR TITLE
Add ability to reset stats and arrays.

### DIFF
--- a/pixelstac/pointstats.py
+++ b/pixelstac/pointstats.py
@@ -179,6 +179,15 @@ class Point:
         return self.item_stats
 
 
+    def reset(self):
+        """
+        Remove all stats from the attached ItemStats objects.
+
+        """
+        for stats in self.item_stats.values():
+            stats.reset()
+
+
     def get_item_stats(self, item_id):
         """
         Return the ItemStats object for this point that corresponds to the
@@ -316,6 +325,15 @@ class ItemPoints(PointCollection):
         return self.item
 
 
+    def reset(self):
+        """
+        Remove the statistics for every point.
+
+        """
+        for pt in self.points:
+            pt.reset()
+
+
 class ImagePoints(PointCollection):
     """
     A collection of points that intersect a standard Image, represented
@@ -428,6 +446,14 @@ class ItemStats:
 
         """
         return self.stats[stat_name]
+
+
+    def reset(self):
+        """
+        Delete all previously calculated stats and raw arrays.
+
+        """
+        self.stats = {}
 
 
 ################################################


### PR DESCRIPTION
@gillins. For the cibo ETL pipeline, I found that I after calculating the reflectance statistics, I wanted to reuse the same points to get cloud-mask info from the SCL layer. I need to remove the reflectance stats before calculating the SCL stats. I think we'll need to do the same for the ancillary layers.